### PR TITLE
create: find user rol from useAdmin hook

### DIFF
--- a/src/Component/Dashboard/Dashboard.jsx
+++ b/src/Component/Dashboard/Dashboard.jsx
@@ -1,26 +1,24 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import UserDashboard from "./UserDashboard";
 import AdminDashboard from "./AdminDashboard";
+import useAdmin from "../Hooks/useAdmin/useAdmin";
+import useAuth from './../Hooks/useAuth';
 
 const Dashboard = () => {
-  const [role, setRole] = useState(null); // "user" or "admin"
-  const navigate = useNavigate();
+  // Get user from useAuth
+  const { user } = useAuth();
+  
+  // Get role from useAdmin and pass the user
+  const { role, loading, error } = useAdmin(user);
 
-  useEffect(() => {
-    // Mock role fetching, replace this with API or auth logic
-    const userRole = localStorage.getItem("userRole"); // e.g., from auth token
-    console.log(userRole);
-    if (!userRole) {
-      navigate("/login"); // Redirect to login if not authenticated
-    }
-    setRole(userRole);
-  }, [navigate]);
-
-  if (!role) {
+  if (loading) {
     return <p>Loading...</p>;
   }
 
+  if (error) {
+    return <p>Error: {error}</p>;
+  }
+
+ 
   return (
     <div>
       {role === "admin" ? <AdminDashboard /> : <UserDashboard />}

--- a/src/Component/Hooks/useAdmin/useAdmin.jsx
+++ b/src/Component/Hooks/useAdmin/useAdmin.jsx
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import useAxiosSecure from '../useAxiosSecure';
+
+const useAdmin = (user) => {
+  const axiosSecure = useAxiosSecure();
+  const [role, setRole] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!user?.email) return;
+
+    const fetchUserData = async () => {
+      setLoading(true);
+      try {
+        const response = await axiosSecure.get(`/api/me/${user.email}`);
+        setRole(response.data.role); 
+      } catch (err) {
+        setError(err.message || 'An unknown error occurred');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUserData();
+  }, [user?.email, axiosSecure]);
+
+  return { role, loading, error };
+};
+
+export default useAdmin;


### PR DESCRIPTION
I created a hook to fetch the user’s role from the database using an API endpoint: api/me/{user?.email}. I use this hook on the dashboard to navigate the user to the appropriate route—redirecting a regular user to the user route and an admin to the admin route